### PR TITLE
bumblebee-status: add module

### DIFF
--- a/modules/lib/maintainers.nix
+++ b/modules/lib/maintainers.nix
@@ -19,6 +19,12 @@
     githubId = 56743515;
     name = "Morgane Austreelis";
   };
+  augustebaum = {
+    email = "auguste.apple@gmail.com";
+    github = "augustebaum";
+    githubId = 52001167;
+    name = "Auguste Baum";
+  };
   blmhemu = {
     name = "blmhemu";
     email = "19410501+blmhemu@users.noreply.github.com";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -67,6 +67,7 @@ let
     ./programs/broot.nix
     ./programs/browserpass.nix
     ./programs/btop.nix
+    ./programs/bumblebee-status.nix
     ./programs/carapace.nix
     ./programs/chromium.nix
     ./programs/command-not-found/command-not-found.nix

--- a/modules/programs/bumblebee-status.nix
+++ b/modules/programs/bumblebee-status.nix
@@ -1,0 +1,219 @@
+{ config, lib, pkgs, ... }:
+with lib;
+with types;
+let cfg = config.programs.bumblebee-status;
+in {
+  meta.maintainers = with lib.maintainers; [ augustebaum ];
+
+  options.programs.bumblebee-status = {
+    enable = mkEnableOption
+      "a modular, theme-able status line generator for the i3 window manager";
+
+    plugins = let
+      plugin = submodule {
+        options = {
+          name = mkOption {
+            type = str;
+            description = "Name of the plugin.";
+            example = "memory";
+          };
+
+          alias = mkOption {
+            type = nullOr str;
+            description =
+              "Alias to refer to this plugin with. This allows for using plugins more than once, as described in <https://bumblebee-status.readthedocs.io/en/main/introduction.html?highlight=aliases#usage>.";
+            default = null;
+          };
+
+          parameters = mkOption {
+            type = attrs;
+            description =
+              "Parameters to run the plugin with. See <https://bumblebee-status.readthedocs.io/en/main/features.html#advanced-usage> for explanations and showcase of the available parameters.";
+            default = { };
+            example = literalExpression ''
+              {
+                interval = "2m30s";
+                left-click = "nautilus {instance}";
+                theme.minwidth = "10,10,10,10";
+                scrolling.bounce = true;
+              }
+            '';
+          };
+
+          autohide = mkOption {
+            type = bool;
+            description = ''
+              Whether to hide the plugin by default, only showing it when its state is "warning" or "error". See <https://bumblebee-status.readthedocs.io/en/main/features.html#automatically-hiding-modules> for more information.'';
+            default = false;
+          };
+
+          errorhide = mkOption {
+            type = bool;
+            description =
+              ''Whether to hide the plugin when its state is "error".'';
+            default = false;
+          };
+        };
+      };
+    in mkOption {
+      # NOTE: Needs to be a list to preserve the order
+      type = listOf plugin;
+      # FIXME: I would shorten the alias explanation since there is an option for it (opt.plugins.*.alias), but I can't figure out how to use the `opt` stuff to refer to it since it is in a list.
+      description = ''
+        List of plugins to use.
+        The plugins will appear on the bar from left to right, except if ${opt.parameters.right-to-left} is used.
+        Note that a plugin can be used more than once using the alias mechanic described in <https://bumblebee-status.readthedocs.io/en/main/introduction.html?highlight=aliased#usage>.
+        See <https://bumblebee-status.readthedocs.io/en/main/modules.html> for the list of available plugins (or "modules").
+      '';
+      default = [ ];
+      example = literalExpression ''
+        [
+          { name = "memory"; }
+          {
+            name = "battery";
+            parameters = {
+              interval = "2m30s";
+              left-click = "nautilus {instance}";
+              theme.minwidth = "10,10,10,10";
+              scrolling.bounce = true;
+            };
+          }
+        ]
+      '';
+    };
+
+    right-to-left = mkOption {
+      type = bool;
+      description = "Whether to display plugins from right to left.";
+      default = false;
+    };
+
+    theme = mkOption {
+      type = str;
+      description =
+        "Theme to use. See <https://bumblebee-status.readthedocs.io/en/main/themes.html> for the list of available themes.";
+      default = "default";
+      example = "gruvbox";
+    };
+
+    interval = mkOption {
+      type = either ints.positive str;
+      description =
+        "Global refresh interval. Either an integer which will be converted to seconds, or a string with units. See <https://bumblebee-status.readthedocs.io/en/main/features.html#intervals> for more information. Note that a plugin's refresh interval cannot be smaller than this interval.";
+      default = 1; # second
+      example = "3m";
+    };
+
+    package = mkOption {
+      type = package;
+      default = pkgs.bumblebee-status;
+      defaultText = literalExpression "pkgs.bumblebee-status";
+      description = "The bumblebee-status package to use.";
+    };
+  };
+
+  config = mkIf cfg.enable (let
+    # getNames :: [Plugin] -> [string]
+    getNames = lib.attrsets.catAttrs "name";
+
+    # join :: [string] -> string
+    join = builtins.concatStringsSep ",";
+
+    pluginNames = getNames cfg.plugins;
+
+    autohide = join (getNames (builtins.filter (p: p.autohide) cfg.plugins));
+    errorhide = join (getNames (builtins.filter (p: p.errorhide) cfg.plugins));
+
+    # getModuleName :: Plugin -> string
+    getModuleName = p:
+      if (p.alias == null) then p.name else "${p.name}:${p.alias}";
+
+    modules = join (map getModuleName cfg.plugins);
+
+    # mkModuleParameters :: Plugin -> {string: PluginParameters}
+    mkModuleParameters = p:
+      let moduleId = if (p.alias == null) then p.name else p.alias;
+      in { "${moduleId}" = p.parameters; };
+
+    # mergeParameters :: [AttrSet] -> AttrSet
+    mergeParameters = lib.lists.fold lib.trivial.mergeAttrs { };
+
+    filterEmpty = lib.attrsets.filterAttrs (_: v: v != { });
+
+    # flattenAttrs :: string -> AttrSet -> AttrSet
+    # flattenAttrs "." { a = { b = { c = 1; }; }; } => { "a.b.c" = 1; }
+    flattenAttrs = sep: x:
+      let
+        f = path:
+          lib.attrsets.foldlAttrs (acc: name: value:
+            (if builtins.isAttrs value then
+              (f "${path}${name}${sep}" value)
+            else {
+              "${path}${name}" = value;
+            }) // acc) { };
+      in f "" x;
+
+    module-parameters = flattenAttrs "."
+      (filterEmpty (mergeParameters (map mkModuleParameters cfg.plugins)));
+  in {
+    assertions = let
+      aliases =
+        filter (x: x != null) (lib.attrsets.catAttrs "alias" cfg.plugins);
+
+      # findDuplicates :: [a] -> [a]
+      findDuplicates = xs:
+        let
+          # helper :: [a] -> {seen: [a]; duplicates: [a]}
+          helper = foldl (acc: v: {
+            seen = acc.seen ++ [ v ];
+            duplicates = if elem v acc.seen then
+              acc.duplicates ++ [ v ]
+            else
+              acc.duplicates;
+          }) {
+            seen = [ ];
+            duplicates = [ ];
+          };
+        in lib.lists.unique (helper xs).duplicates;
+
+      duplicateAliases = findDuplicates aliases;
+
+      prettyPrintList = xs:
+        let wrapInQuotes = map (s: ''"${s}"'');
+        in "[ " + (concatStringsSep ", " (wrapInQuotes xs)) + " ]";
+
+      intersectionAliasesPluginNames = intersectLists aliases pluginNames;
+    in [
+      {
+        assertion = duplicateAliases == [ ];
+        message =
+          "No two plugin aliases can be the same. List of offending aliases is: ${
+            prettyPrintList duplicateAliases
+          }.";
+      }
+      {
+        assertion = intersectionAliasesPluginNames == [ ];
+        message =
+          "No plugin alias can be the same as a plugin name. List of offending names is: ${
+            prettyPrintList intersectionAliasesPluginNames
+          }.";
+      }
+    ];
+
+    home.packages = [ (cfg.package.override { withPlugins = pluginNames; }) ];
+
+    xdg.configFile."bumblebee-status/config" = {
+      text = let
+        generateINI = generators.toINI {
+          mkKeyValue = generators.mkKeyValueDefault { } " = ";
+        };
+      in generateINI {
+        core = {
+          inherit modules autohide errorhide;
+          inherit (cfg) theme right-to-left interval;
+        };
+        inherit module-parameters;
+      };
+    };
+  });
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,250 +1,252 @@
-{ pkgs ? import <nixpkgs> {}, enableBig ? true }:
-
-let
-
+{
+  pkgs ? import <nixpkgs> {},
+  enableBig ? true,
+}: let
   lib = import ../modules/lib/stdlib-extended.nix pkgs.lib;
 
   nmt = fetchTarball {
-    url =
-      "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=4df00c569b1badfedffecd7ccd60f794550486db";
+    url = "https://gitlab.com/api/v4/projects/rycee%2Fnmt/repository/archive.tar.gz?sha=4df00c569b1badfedffecd7ccd60f794550486db";
     sha256 = "1cyly1zazgj8z6bazml4js7lqaqvpp8lw045aqchlpvp42bl1lp4";
   };
 
-  modules = import ../modules/modules.nix {
-    inherit lib pkgs;
-    check = false;
-  } ++ [
-    {
-      # Bypass <nixpkgs> reference inside modules/modules.nix to make the test
-      # suite more pure.
-      _module.args.pkgsPath = pkgs.path;
-
-      # Fix impurities. Without these some of the user's environment
-      # will leak into the tests through `builtins.getEnv`.
-      xdg.enable = true;
-      home = {
-        username = "hm-user";
-        homeDirectory = "/home/hm-user";
-        stateVersion = lib.mkDefault "18.09";
-      };
-
-      # Avoid including documentation since this will cause
-      # unnecessary rebuilds of the tests.
-      manual.manpages.enable = lib.mkDefault false;
-
-      imports = [ ./asserts.nix ./big-test.nix ./stubs.nix ];
-
-      test.enableBig = enableBig;
+  modules =
+    import ../modules/modules.nix {
+      inherit lib pkgs;
+      check = false;
     }
-  ];
+    ++ [
+      {
+        # Bypass <nixpkgs> reference inside modules/modules.nix to make the test
+        # suite more pure.
+        _module.args.pkgsPath = pkgs.path;
+
+        # Fix impurities. Without these some of the user's environment
+        # will leak into the tests through `builtins.getEnv`.
+        xdg.enable = true;
+        home = {
+          username = "hm-user";
+          homeDirectory = "/home/hm-user";
+          stateVersion = lib.mkDefault "18.09";
+        };
+
+        # Avoid including documentation since this will cause
+        # unnecessary rebuilds of the tests.
+        manual.manpages.enable = lib.mkDefault false;
+
+        imports = [./asserts.nix ./big-test.nix ./stubs.nix];
+
+        test.enableBig = enableBig;
+      }
+    ];
 
   isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
   isLinux = pkgs.stdenv.hostPlatform.isLinux;
-
 in
-
-import nmt {
-  inherit lib pkgs modules;
-  testedAttrPath = [ "home" "activationPackage" ];
-  tests = builtins.foldl' (a: b: a // (import b)) { } ([
-    ./lib/generators
-    ./lib/types
-    ./modules/files
-    ./modules/home-environment
-    ./modules/misc/fontconfig
-    ./modules/misc/manual
-    ./modules/misc/nix
-    ./modules/misc/specialisation
-    ./modules/programs/aerc
-    ./modules/programs/alacritty
-    ./modules/programs/alot
-    ./modules/programs/antidote
-    ./modules/programs/aria2
-    ./modules/programs/atuin
-    ./modules/programs/autojump
-    ./modules/programs/bash
-    ./modules/programs/bat
-    ./modules/programs/bottom
-    ./modules/programs/broot
-    ./modules/programs/browserpass
-    ./modules/programs/btop
-    ./modules/programs/carapace
-    ./modules/programs/comodoro
-    ./modules/programs/darcs
-    ./modules/programs/dircolors
-    ./modules/programs/direnv
-    ./modules/programs/emacs
-    ./modules/programs/feh
-    ./modules/programs/fish
-    ./modules/programs/gallery-dl
-    ./modules/programs/gh
-    ./modules/programs/gh-dash
-    ./modules/programs/git-cliff
-    ./modules/programs/git
-    ./modules/programs/gpg
-    ./modules/programs/helix
-    ./modules/programs/himalaya
-    ./modules/programs/htop
-    ./modules/programs/hyfetch
-    ./modules/programs/i3status
-    ./modules/programs/irssi
-    ./modules/programs/jujutsu
-    ./modules/programs/k9s
-    ./modules/programs/kakoune
-    ./modules/programs/kitty
-    ./modules/programs/khal
-    ./modules/programs/ledger
-    ./modules/programs/less
-    ./modules/programs/lf
-    ./modules/programs/lieer
-    ./modules/programs/man
-    ./modules/programs/mbsync
-    ./modules/programs/micro
-    ./modules/programs/mpv
-    ./modules/programs/mu
-    ./modules/programs/mujmap
-    ./modules/programs/ncmpcpp
-    ./modules/programs/ne
-    ./modules/programs/neomutt
-    ./modules/programs/neovim
-    ./modules/programs/newsboat
-    ./modules/programs/nheko
-    ./modules/programs/nix-index
-    ./modules/programs/nnn
-    ./modules/programs/nushell
-    ./modules/programs/oh-my-posh
-    ./modules/programs/pandoc
-    ./modules/programs/papis
-    ./modules/programs/pet
-    ./modules/programs/pistol
-    ./modules/programs/pls
-    ./modules/programs/powerline-go
-    ./modules/programs/pubs
-    ./modules/programs/pyenv
-    ./modules/programs/qcal
-    ./modules/programs/qutebrowser
-    ./modules/programs/readline
-    ./modules/programs/ripgrep
-    ./modules/programs/rtx
-    ./modules/programs/sagemath
-    ./modules/programs/sbt
-    ./modules/programs/scmpuff
-    ./modules/programs/sioyek
-    ./modules/programs/sm64ex
-    ./modules/programs/ssh
-    ./modules/programs/starship
-    ./modules/services/syncthing/common
-    ./modules/programs/taskwarrior
-    ./modules/programs/texlive
-    ./modules/programs/tmate
-    ./modules/programs/tmux
-    ./modules/programs/topgrade
-    ./modules/programs/translate-shell
-    ./modules/programs/vim-vint
-    ./modules/programs/vscode
-    ./modules/programs/watson
-    ./modules/programs/wezterm
-    ./modules/programs/yazi
-    ./modules/programs/zellij
-    ./modules/programs/zplug
-    ./modules/programs/zsh
-    ./modules/xresources
-  ] ++ lib.optionals isDarwin [
-    ./modules/launchd
-    ./modules/services/git-sync-darwin
-    ./modules/services/imapnotify-darwin
-    ./modules/targets-darwin
-  ] ++ lib.optionals isLinux [
-    ./modules/config/i18n
-    ./modules/i18n/input-method
-    ./modules/misc/debug
-    ./modules/misc/editorconfig
-    ./modules/misc/gtk
-    ./modules/misc/numlock
-    ./modules/misc/pam
-    ./modules/misc/qt
-    ./modules/misc/xdg
-    ./modules/misc/xsession
-    ./modules/programs/abook
-    ./modules/programs/autorandr
-    ./modules/programs/beets  # One test relies on services.mpd
-    ./modules/programs/borgmatic
-    ./modules/programs/boxxy
-    ./modules/programs/firefox
-    ./modules/programs/foot
-    ./modules/programs/fuzzel
-    ./modules/programs/getmail
-    ./modules/programs/gnome-terminal
-    ./modules/programs/hexchat
-    ./modules/programs/i3status-rust
-    ./modules/programs/imv
-    ./modules/programs/kodi
-    ./modules/programs/looking-glass-client
-    ./modules/programs/mangohud
-    ./modules/programs/ncmpcpp-linux
-    ./modules/programs/pqiv
-    ./modules/programs/rbw
-    ./modules/programs/rofi
-    ./modules/programs/rofi-pass
-    ./modules/programs/swaylock
-    ./modules/programs/terminator
-    ./modules/programs/thunderbird
-    ./modules/programs/waybar
-    ./modules/programs/wlogout
-    ./modules/programs/wofi
-    ./modules/programs/xmobar
-    ./modules/programs/yt-dlp
-    ./modules/services/avizo
-    ./modules/services/barrier
-    ./modules/services/borgmatic
-    ./modules/services/cachix-agent
-    ./modules/services/clipman
-    ./modules/services/comodoro
-    ./modules/services/devilspie2
-    ./modules/services/dropbox
-    ./modules/services/emacs
-    ./modules/services/espanso
-    ./modules/services/flameshot
-    ./modules/services/fluidsynth
-    ./modules/services/fnott
-    ./modules/services/fusuma
-    ./modules/services/git-sync
-    ./modules/services/gpg-agent
-    ./modules/services/gromit-mpx
-    ./modules/services/home-manager-auto-upgrade
-    ./modules/services/imapnotify
-    ./modules/services/kanshi
-    ./modules/services/lieer
-    ./modules/services/mopidy
-    ./modules/services/mpd
-    ./modules/services/mpdris2
-    ./modules/services/mpd-mpris
-    ./modules/services/pantalaimon
-    ./modules/services/parcellite
-    ./modules/services/pass-secret-service
-    ./modules/services/pbgopy
-    ./modules/services/picom
-    ./modules/services/playerctld
-    ./modules/services/polybar
-    ./modules/services/recoll
-    ./modules/services/redshift-gammastep
-    ./modules/services/screen-locker
-    ./modules/services/swayidle
-    ./modules/services/swayosd
-    ./modules/services/sxhkd
-    ./modules/services/syncthing/linux
-    ./modules/services/trayer
-    ./modules/services/twmn
-    ./modules/services/udiskie
-    ./modules/services/window-managers/bspwm
-    ./modules/services/window-managers/herbstluftwm
-    ./modules/services/window-managers/hyprland
-    ./modules/services/window-managers/i3
-    ./modules/services/window-managers/spectrwm
-    ./modules/services/window-managers/sway
-    ./modules/services/wlsunset
-    ./modules/services/xsettingsd
-    ./modules/systemd
-    ./modules/targets-linux
-  ]);
-}
+  import nmt {
+    inherit lib pkgs modules;
+    testedAttrPath = ["home" "activationPackage"];
+    tests = builtins.foldl' (a: b: a // (import b)) {} ([
+        ./lib/generators
+        ./lib/types
+        ./modules/files
+        ./modules/home-environment
+        ./modules/misc/fontconfig
+        ./modules/misc/manual
+        ./modules/misc/nix
+        ./modules/misc/specialisation
+        ./modules/programs/aerc
+        ./modules/programs/alacritty
+        ./modules/programs/alot
+        ./modules/programs/antidote
+        ./modules/programs/aria2
+        ./modules/programs/atuin
+        ./modules/programs/autojump
+        ./modules/programs/bash
+        ./modules/programs/bat
+        ./modules/programs/bottom
+        ./modules/programs/broot
+        ./modules/programs/browserpass
+        ./modules/programs/btop
+        ./modules/programs/bumblebee-status
+        ./modules/programs/carapace
+        ./modules/programs/comodoro
+        ./modules/programs/darcs
+        ./modules/programs/dircolors
+        ./modules/programs/direnv
+        ./modules/programs/emacs
+        ./modules/programs/feh
+        ./modules/programs/fish
+        ./modules/programs/gallery-dl
+        ./modules/programs/gh
+        ./modules/programs/gh-dash
+        ./modules/programs/git-cliff
+        ./modules/programs/git
+        ./modules/programs/gpg
+        ./modules/programs/helix
+        ./modules/programs/himalaya
+        ./modules/programs/htop
+        ./modules/programs/hyfetch
+        ./modules/programs/i3status
+        ./modules/programs/irssi
+        ./modules/programs/jujutsu
+        ./modules/programs/k9s
+        ./modules/programs/kakoune
+        ./modules/programs/kitty
+        ./modules/programs/khal
+        ./modules/programs/ledger
+        ./modules/programs/less
+        ./modules/programs/lf
+        ./modules/programs/lieer
+        ./modules/programs/man
+        ./modules/programs/mbsync
+        ./modules/programs/micro
+        ./modules/programs/mpv
+        ./modules/programs/mu
+        ./modules/programs/mujmap
+        ./modules/programs/ncmpcpp
+        ./modules/programs/ne
+        ./modules/programs/neomutt
+        ./modules/programs/neovim
+        ./modules/programs/newsboat
+        ./modules/programs/nheko
+        ./modules/programs/nix-index
+        ./modules/programs/nnn
+        ./modules/programs/nushell
+        ./modules/programs/oh-my-posh
+        ./modules/programs/pandoc
+        ./modules/programs/papis
+        ./modules/programs/pet
+        ./modules/programs/pistol
+        ./modules/programs/pls
+        ./modules/programs/powerline-go
+        ./modules/programs/pubs
+        ./modules/programs/pyenv
+        ./modules/programs/qcal
+        ./modules/programs/qutebrowser
+        ./modules/programs/readline
+        ./modules/programs/ripgrep
+        ./modules/programs/rtx
+        ./modules/programs/sagemath
+        ./modules/programs/sbt
+        ./modules/programs/scmpuff
+        ./modules/programs/sioyek
+        ./modules/programs/sm64ex
+        ./modules/programs/ssh
+        ./modules/programs/starship
+        ./modules/services/syncthing/common
+        ./modules/programs/taskwarrior
+        ./modules/programs/texlive
+        ./modules/programs/tmate
+        ./modules/programs/tmux
+        ./modules/programs/topgrade
+        ./modules/programs/translate-shell
+        ./modules/programs/vim-vint
+        ./modules/programs/vscode
+        ./modules/programs/watson
+        ./modules/programs/wezterm
+        ./modules/programs/yazi
+        ./modules/programs/zellij
+        ./modules/programs/zplug
+        ./modules/programs/zsh
+        ./modules/xresources
+      ]
+      ++ lib.optionals isDarwin [
+        ./modules/launchd
+        ./modules/services/git-sync-darwin
+        ./modules/services/imapnotify-darwin
+        ./modules/targets-darwin
+      ]
+      ++ lib.optionals isLinux [
+        ./modules/config/i18n
+        ./modules/i18n/input-method
+        ./modules/misc/debug
+        ./modules/misc/editorconfig
+        ./modules/misc/gtk
+        ./modules/misc/numlock
+        ./modules/misc/pam
+        ./modules/misc/qt
+        ./modules/misc/xdg
+        ./modules/misc/xsession
+        ./modules/programs/abook
+        ./modules/programs/autorandr
+        ./modules/programs/beets # One test relies on services.mpd
+        ./modules/programs/borgmatic
+        ./modules/programs/boxxy
+        ./modules/programs/firefox
+        ./modules/programs/foot
+        ./modules/programs/fuzzel
+        ./modules/programs/getmail
+        ./modules/programs/gnome-terminal
+        ./modules/programs/hexchat
+        ./modules/programs/i3status-rust
+        ./modules/programs/imv
+        ./modules/programs/kodi
+        ./modules/programs/looking-glass-client
+        ./modules/programs/mangohud
+        ./modules/programs/ncmpcpp-linux
+        ./modules/programs/pqiv
+        ./modules/programs/rbw
+        ./modules/programs/rofi
+        ./modules/programs/rofi-pass
+        ./modules/programs/swaylock
+        ./modules/programs/terminator
+        ./modules/programs/thunderbird
+        ./modules/programs/waybar
+        ./modules/programs/wlogout
+        ./modules/programs/wofi
+        ./modules/programs/xmobar
+        ./modules/programs/yt-dlp
+        ./modules/services/avizo
+        ./modules/services/barrier
+        ./modules/services/borgmatic
+        ./modules/services/cachix-agent
+        ./modules/services/clipman
+        ./modules/services/comodoro
+        ./modules/services/devilspie2
+        ./modules/services/dropbox
+        ./modules/services/emacs
+        ./modules/services/espanso
+        ./modules/services/flameshot
+        ./modules/services/fluidsynth
+        ./modules/services/fnott
+        ./modules/services/fusuma
+        ./modules/services/git-sync
+        ./modules/services/gpg-agent
+        ./modules/services/gromit-mpx
+        ./modules/services/home-manager-auto-upgrade
+        ./modules/services/imapnotify
+        ./modules/services/kanshi
+        ./modules/services/lieer
+        ./modules/services/mopidy
+        ./modules/services/mpd
+        ./modules/services/mpdris2
+        ./modules/services/mpd-mpris
+        ./modules/services/pantalaimon
+        ./modules/services/parcellite
+        ./modules/services/pass-secret-service
+        ./modules/services/pbgopy
+        ./modules/services/picom
+        ./modules/services/playerctld
+        ./modules/services/polybar
+        ./modules/services/recoll
+        ./modules/services/redshift-gammastep
+        ./modules/services/screen-locker
+        ./modules/services/swayidle
+        ./modules/services/swayosd
+        ./modules/services/sxhkd
+        ./modules/services/syncthing/linux
+        ./modules/services/trayer
+        ./modules/services/twmn
+        ./modules/services/udiskie
+        ./modules/services/window-managers/bspwm
+        ./modules/services/window-managers/herbstluftwm
+        ./modules/services/window-managers/hyprland
+        ./modules/services/window-managers/i3
+        ./modules/services/window-managers/spectrwm
+        ./modules/services/window-managers/sway
+        ./modules/services/wlsunset
+        ./modules/services/xsettingsd
+        ./modules/systemd
+        ./modules/targets-linux
+      ]);
+  }

--- a/tests/modules/programs/bumblebee-status/bumblebee-status.nix
+++ b/tests/modules/programs/bumblebee-status/bumblebee-status.nix
@@ -36,6 +36,17 @@
 
   test.stubs.bumblebee-status = { };
 
+  # FIXME: This and the ./bumblebee-status directory should be removed when bumblebee-status is merged into nixpkgs
+  nixpkgs.overlays = [
+    (final: prev: {
+      bumblebee-status = pkgs.callPackage ./bumblebee-status { };
+      bumblebee-status-full = let
+        allPlugins = pkgs.callPackage ./bumblebee-status/plugins.nix { };
+        allPluginNames = map (p: p.name) allPlugins;
+      in pkgs.callPackage ./bumblebee-status { withPlugins = allPluginNames; };
+    })
+  ];
+
   nmt.script = ''
     assertFileExists home-files/.config/bumblebee-status/config
     assertFileContent home-files/.config/bumblebee-status/config ${

--- a/tests/modules/programs/bumblebee-status/bumblebee-status.nix
+++ b/tests/modules/programs/bumblebee-status/bumblebee-status.nix
@@ -1,0 +1,45 @@
+{ pkgs, ... }: {
+  home.enableNixpkgsReleaseCheck = false;
+
+  programs.bumblebee-status = {
+    enable = true;
+    plugins = [
+      {
+        name = "pulsein";
+        alias = "micro";
+        parameters.left-click = "nix run nixpkgs#pavucontrol";
+      }
+      {
+        name = "pulseout";
+        parameters.left-click = "nix run nixpkgs#pavucontrol";
+      }
+      {
+        name = "playerctl";
+        autohide = true;
+      }
+      {
+        name = "battery";
+        errorhide = true;
+        autohide = true;
+      }
+      { name = "time"; }
+      { name = "arandr"; }
+      {
+        name = "xkcd";
+        autohide = true;
+      }
+      { name = "system"; }
+    ];
+    theme = "default";
+    interval = 1;
+  };
+
+  test.stubs.bumblebee-status = { };
+
+  nmt.script = ''
+    assertFileExists home-files/.config/bumblebee-status/config
+    assertFileContent home-files/.config/bumblebee-status/config ${
+      ./expected.ini
+    }
+  '';
+}

--- a/tests/modules/programs/bumblebee-status/bumblebee-status/default.nix
+++ b/tests/modules/programs/bumblebee-status/bumblebee-status/default.nix
@@ -1,0 +1,63 @@
+{ pkgs, lib, python3, python3Packages, fetchFromGitHub, withPlugins ? null, ...
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "bumblebee-status";
+  version = "2.1.6";
+
+  src = fetchFromGitHub {
+    owner = "tobi-wan-kenobi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-Oo7n3NyUxBedQHG5P7TM9nuI2hwnVN1SJcK9OP3yiyE=";
+  };
+
+  propagatedBuildInputs = let
+    allPlugins = import ./plugins.nix { inherit pkgs python3Packages; };
+
+    isSelected = plugin: builtins.elem plugin.name withPlugins;
+
+    selectedPlugins = lib.filter isSelected allPlugins;
+
+    pluginPropagatedBuildInputs =
+      lib.attrsets.catAttrs "requires" selectedPlugins;
+  in lib.lists.unique pluginPropagatedBuildInputs;
+
+  checkInputs = with python3Packages; [
+    freezegun
+    netifaces
+    psutil
+    pytest
+    pytest-mock
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    # Fixes `locale.Error: unsupported locale setting` in some tests.
+    export LOCALE_ARCHIVE="${pkgs.glibcLocales}/lib/locale/locale-archive";
+
+    # FIXME: We skip the `dunst` module tests, some of which fail with
+    # `RuntimeError: killall -s SIGUSR2 dunst not found`.
+    # This is not solved by adding `pkgs.killall` to `checkInputs`.
+    ${python3.interpreter} -m pytest -k 'not test_dunst.py'
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    # Remove binary cache files
+    find $out -name "__pycache__" -type d | xargs rm -rv
+
+    # Make themes available for bumblebee-status to detect them
+    cp -r ./themes $out/${python3.sitePackages}
+  '';
+
+  meta = with lib; {
+    description =
+      "bumblebee-status is a modular, theme-able status line generator for the i3 window manager.";
+    homepage = "https://bumblebee-status.readthedocs.io/";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ augustebaum ];
+  };
+}

--- a/tests/modules/programs/bumblebee-status/bumblebee-status/plugins.nix
+++ b/tests/modules/programs/bumblebee-status/bumblebee-status/plugins.nix
@@ -1,0 +1,375 @@
+{ pkgs, python3Packages, ... }:
+with pkgs;
+with python3Packages;
+let
+  mkPluginCfg = { name, requires ? [ ], requiresUnpackaged ? [ ], optional ? [ ]
+    , warnings ? [ ], }: rec {
+      inherit name requires requiresUnpackaged optional;
+      warnings = let
+        warn = dep:
+          ''
+            Plugin "${name}": Dependency `${dep}` is not known to be contained in Nixpkgs, so plugin might fail at runtime.'';
+        requiresUnpackagedWarnings = map warn requiresUnpackaged;
+      in warnings ++ requiresUnpackagedWarnings;
+    };
+in map mkPluginCfg [
+  {
+    name = "amixer";
+    requires = [ alsa-utils ];
+  }
+  # {
+  #   name = "apt";
+  #   requiresUnpackaged = ["aptitude"];
+  # }
+  {
+    name = "arandr";
+    requires = [ tkinter arandr xorg.xrandr ];
+  }
+  # {
+  #   name = "arch-update";
+  #   requiresUnpackaged = ["checkupdates"];
+  # }
+  # {
+  #   name = "arch_update";
+  #   requiresUnpackaged = ["checkupdates"];
+  # }
+  # {
+  #   name = "aur-update";
+  #   requiresUnpackaged = ["yay"];
+  # }
+  { name = "battery"; }
+  { name = "battery-upower"; }
+  { name = "battery_upower"; }
+  {
+    name = "bluetooth";
+    requires = [ bluez blueman dbus ];
+  }
+  {
+    name = "bluetooth2";
+    requires = [ bluez blueman dbus dbus-python ];
+  }
+  {
+    name = "blugon";
+    requires = [ blugon ];
+  }
+  {
+    name = "brightness";
+    optional = [ brightnessctl light xbacklight ];
+    warnings = [
+      "If you do not allow this plugin to query the system's ACPI, i.e. the plugin option `use_acpi` is set to `False`, then you need at least one of the optional dependencies."
+    ];
+  }
+  {
+    name = "caffeine";
+    requires = [ xdg-utils xdotool xorg.xprop libnotify ];
+  }
+  {
+    name = "cmus";
+    requires = [ cmus ];
+  }
+  {
+    name = "cpu";
+    requires = [ psutil gnome.gnome-system-monitor ];
+  }
+  {
+    name = "cpu2";
+    requires = [ psutil lm_sensors ];
+  }
+  {
+    name = "currency";
+    requires = [ requests ];
+  }
+  { name = "date"; }
+  { name = "datetime"; }
+  {
+    name = "datetimetz";
+    requires = [ tzlocal pytz ];
+  }
+  { name = "datetz"; }
+  {
+    name = "deadbeef";
+    requires = [ deadbeef ];
+  }
+  { name = "debug"; }
+  {
+    name = "deezer";
+    requires = [ dbus-python ];
+  }
+  {
+    name = "disk";
+  }
+  # {
+  #   name = "dnf";
+  #   requiresUnpackaged = ["dnf"];
+  # }
+  {
+    name = "docker_ps";
+    requires = [ python3Packages.docker ];
+  }
+  {
+    name = "dunst";
+    requires = [ dunst ];
+  }
+  {
+    name = "dunstctl";
+    requires = [ dunst ];
+  }
+  # {
+  #   name = "emerge_status";
+  #   requiresUnpackaged = ["emerge"];
+  # }
+  { name = "error"; }
+  {
+    name = "gcalendar";
+    requires =
+      [ google-api-python-client google-auth-httplib2 google-auth-oauthlib ];
+  }
+  {
+    name = "getcrypto";
+    requires = [ requests ];
+  }
+  {
+    name = "git";
+    requires = [ xcwd pygit2 ];
+  }
+  {
+    name = "github";
+    requires = [ requests ];
+  }
+  # {
+  #   name = "gpmdp";
+  #   requiresUnpackaged = ["gpmdp-remote"];
+  # }
+  { name = "hddtemp"; }
+  { name = "hostname"; }
+  { name = "http_status"; }
+  {
+    name = "indicator";
+    requires = [ xorg.xset ];
+  }
+  { name = "kernel"; }
+  {
+    name = "keys";
+  }
+  # {
+  #   name = "layout";
+  #   requiresUnpackaged = ["libX11_unpackaged.so.6" "python3Packages.xkbgroup"];
+  # }
+  # {
+  #   name = "layout-xkb";
+  #   requiresUnpackaged = ["libX11_unpackaged.so.6" "python3Packages.xkbgroup"];
+  # }
+  {
+    name = "layout-xkbswitch";
+    requires = [ xkb-switch ];
+  }
+  # {
+  #   name = "layout_xkb";
+  #   requiresUnpackaged = ["libX11_unpackaged.so.6" "python3Packages.xkbgroup"];
+  # }
+  {
+    name = "layout_xkbswitch";
+    requires = [ xkb-switch ];
+  }
+  {
+    name = "libvirtvms";
+    requires = [ python3Packages.libvirt ];
+  }
+  {
+    name = "load";
+    requires = [ gnome.gnome-system-monitor ];
+  }
+  {
+    name = "memory";
+    requires = [ gnome.gnome-system-monitor ];
+  }
+  { name = "messagereceiver"; }
+  {
+    name = "mocp";
+    requires = [ moc ];
+  }
+  {
+    name = "mpd";
+    requires = [ mpc-cli ];
+  }
+  {
+    name = "network";
+    requires = [ netifaces iw ];
+  }
+  {
+    name = "network_traffic";
+    requires = [ netifaces ];
+  }
+  {
+    name = "nic";
+    requires = [ netifaces iw ];
+  }
+  {
+    name = "notmuch_count";
+    requires = [ notmuch ];
+  }
+  # {
+  #   name = "nvidiagpu";
+  #   requiresUnpackaged = ["nvidia-smi"];
+  # }
+  {
+    name = "octoprint";
+    requires = [ tkinter ];
+  }
+  # {
+  #   name = "optman";
+  #   requiresUnpackaged = ["optimus-manager"];
+  # }
+  {
+    name = "pacman";
+    requires = [ fakeroot pacman ];
+  }
+  {
+    name = "pamixer";
+    requires = [ pamixer ];
+  }
+  {
+    name = "persian_date";
+    requires = [ jdatetime ];
+  }
+  { name = "pihole"; }
+  {
+    name = "ping";
+    requires = [
+      # ping
+    ];
+  }
+  {
+    name = "playerctl";
+    requires = [ playerctl ];
+  }
+  {
+    name = "pomodoro";
+  }
+  # {
+  #   name = "portage_status";
+  #   requiresUnpackaged = ["emerge"];
+  # }
+  # {
+  #   name = "prime";
+  #   requiresUnpackaged = ["prime-select"];
+  # }
+  {
+    name = "progress";
+    requires = [ pkgs.progress ];
+  }
+  {
+    name = "publicip";
+    requires = [ netifaces ];
+  }
+  # pulseaudio = {}; # deprecated
+  {
+    name = "pulsectl";
+    requires = [ pulsectl ];
+  }
+  {
+    name = "redshift";
+    requires = [ redshift ];
+  }
+  # {
+  #   name = "rofication";
+  #   requiresUnpackaged = [ "rofication" ];
+  # }
+  {
+    name = "rotation";
+    requires = [ xorg.xrandr ];
+  }
+  { name = "rss"; }
+  {
+    name = "sensors";
+    requires = [ lm_sensors ];
+  }
+  {
+    name = "sensors2";
+    requires = [ lm_sensors ];
+  }
+  { name = "shell"; }
+  { name = "shortcut"; }
+  {
+    name = "smartstatus";
+    requires = [ smartmontools ];
+  }
+  {
+    name = "solaar";
+    requires = [ solaar ];
+  }
+  {
+    name = "spaceapi";
+    requires = [ requests ];
+  }
+  { name = "spacer"; }
+  {
+    name = "speedtest";
+    requires = [ python3Packages.speedtest-cli ];
+  }
+  {
+    name = "spotify";
+    requires = [ dbus-python ];
+  }
+  {
+    name = "stock";
+  }
+  # {
+  #   name = "sun";
+  #   requires = [ requests python-dateutil ];
+  #   requiresUnpackaged = [ "suntime" ];
+  # }
+  {
+    name = "system";
+    requires = [ tkinter ];
+  }
+  {
+    name = "taskwarrior";
+    requires = [ taskw ];
+  }
+  { name = "test"; }
+  { name = "thunderbird"; }
+  { name = "time"; }
+  { name = "timetz"; }
+  {
+    name = "title";
+    requires = [ i3ipc ];
+  }
+  { name = "todo"; }
+  { name = "todo_org"; }
+  { name = "traffic"; }
+  {
+    name = "twmn";
+    requires = [
+      # systemctl
+    ];
+  }
+  { name = "uptime"; }
+  {
+    name = "vault";
+    requires = [ pass ];
+  }
+  {
+    name = "vpn";
+    requires = [ tkinter networkmanager ];
+  }
+  {
+    name = "watson";
+    requires = [ watson ];
+  }
+  {
+    name = "weather";
+    requires = [ requests ];
+  }
+  { name = "xkcd"; }
+  {
+    name = "xrandr";
+    requires = [ xorg.xrandr ];
+    optional = [ i3 ];
+  }
+  {
+    name = "yubikey";
+    requires = [ python3Packages.yubico ];
+  }
+  { name = "zpool"; }
+]

--- a/tests/modules/programs/bumblebee-status/default.nix
+++ b/tests/modules/programs/bumblebee-status/default.nix
@@ -1,0 +1,1 @@
+{ bumblebee-status = ./bumblebee-status.nix; }

--- a/tests/modules/programs/bumblebee-status/expected.ini
+++ b/tests/modules/programs/bumblebee-status/expected.ini
@@ -1,0 +1,11 @@
+[core]
+autohide = playerctl,battery,xkcd
+errorhide = battery
+interval = 1
+modules = pulsein:micro,pulseout,playerctl,battery,time,arandr,xkcd,system
+right-to-left = false
+theme = default
+
+[module-parameters]
+micro.left-click = nix run nixpkgs#pavucontrol
+pulseout.left-click = nix run nixpkgs#pavucontrol


### PR DESCRIPTION
### Description

<!--

Please provide a brief description of your change.

-->

Add module `programs.bumblebee-status`, a status bar program for use with, e.g., i3.

Importantly, as the package has [not yet been merged into `nixpkgs`](https://github.com/NixOS/nixpkgs/pull/254772), I had to add it manually to the test suite in order to test the module; hence the draft status. Ideally all that remains to be done when the nixpkgs PR is merged is to commit which adds the package.

### Checklist

<!--

Please go through the following checklist before opening a non-WIP
pull-request.

Also make sure to read the guidelines found at

  https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-guidelines

-->

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all` or `nix develop --ignore-environment .#all` using Flakes.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [x] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

#### Maintainer CC

<!--
If you are updating a module, please @ people who are in its `meta.maintainers` list.
If in doubt, check `git blame` for whoever last touched something.
-->
